### PR TITLE
Use model telemetry for linreg week model predictions

### DIFF
--- a/herbrain/config/pregnancy/models/week_mesh/pca_linreg.yaml
+++ b/herbrain/config/pregnancy/models/week_mesh/pca_linreg.yaml
@@ -2,7 +2,9 @@ _target_: polpo.models.SklearnLikeModelFactory
 model:
   _target_: polpo.models.DimReductionBasedMeshRegressor
   model:
-    _target_: sklearn.linear_model.LinearRegression
+    _target_: polpo.preprocessing.sklearn.logging.TelemeteredModel
+    model:
+      _target_: sklearn.linear_model.LinearRegression
   dim_reduction:
     _target_: sklearn.decomposition.PCA
     n_components: 4


### PR DESCRIPTION
This PR uses model telemetry added in https://github.com/luisfpereira/polpo/commit/0d7a6583765f9afaa7557979af2f199b4ded6d6f to log predictions of week_mesh model on pregnancy app.

The way it is configured, it shows `X -> y` that the linear regression really sees/outputs, i.e. after `X` being transformed, and before `y` being transformed back to a mesh.
It can be used also at the outer level.

If this kind of design is interesting, I might also add a `TelemeteredTransformer`, so we can see the input and output of a chosen `transform`.

The message it prints now is pretty ugly:
![Screenshot from 2024-12-19 16-31-20](https://github.com/user-attachments/assets/a5135419-3b92-478b-89ce-5aa848b155fe)
but can be adapted by changing `msg_printer` (which can be simply a callable with signature `(method, model, X, y)`).

Notice these messages can also be deactivate by choosing verbose to be less than 20 (see app arguments).


@ninamiolane, if you like this, please add this telemetry in the config files you want or let me know where I should add them.