### PR TITLE
move pyvista to app config, since it is required to run the app. remo…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ app = [
     "requests",
     "scikit-learn",
     "polpo[dash,mri]@git+https://github.com/geometric-intelligence/polpo.git@main",
+    "pyvista",
 ]
-app-extra = ["pyvista"]
 app-menstrual = ["herbrain[app]", "paramiko", "scp"]
 lddmm = [
     "torch",


### PR DESCRIPTION
…ve app-extra from pyproject.toml, since pyvista was the only thing in it.